### PR TITLE
Bug/payment type fix

### DIFF
--- a/pages/payments.js
+++ b/pages/payments.js
@@ -8,7 +8,7 @@ import Table from '../components/table'
 import { addPaymentType, getPaymentTypes, deletePaymentType } from '../data/payment-types'
 
 export default function Payments() {
-  const headers = ['Merchant Name', 'Card Number', '']
+  const headers = ['Merchant Name', 'Card Number', 'Expiration Date']
   const [payments, setPayments] = useState([])
   const [showModal, setShowModal] = useState(false)
   const refresh = () => getPaymentTypes().then((data) => {
@@ -18,7 +18,7 @@ export default function Payments() {
   })
 
   useEffect(() => {
-    refresh()
+      refresh()
   }, [])
 
   const addNewPayment = (payment) => {
@@ -44,6 +44,7 @@ export default function Payments() {
               <tr key={payment.id}>
                 <td>{payment.merchant_name}</td>
                 <td>{payment.obscured_num}</td>
+                <td>{payment.expiration_date}</td>
                 <td>
                   <span className="icon is-clickable" onClick={() => removePayment(payment.id)}>
                     <i className="fas fa-trash"></i>


### PR DESCRIPTION
##Issue
Payment methods page in browser (pages/payments.js) not displaying expiration date header or info. 

##Fix
-Added 'Expiration Date' to headers array of pages/payments.js
-Added a <td> tag to Table element to include payment.expiration_date when mapping through each payment method that is associated with authenticated user. 

##To Test
-log in with an authenticated user and navigate to the payment methods page. A payment method should appear. Confirm payment method expiration date is correct based on the association in the database. Log out, log in with a different user, and check again. 

##Ticket resolved
#36