### PR TITLE
removed ring diacritic over a in cart in data/orders

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse } from './fetcher'
 
 export function getCart() {
-  return fetchWithResponse('cårt', {
+  return fetchWithResponse('cart', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }


### PR DESCRIPTION
## Issue addressed

Cart was not rendering/error handling was throwing a 404 error. We discovered in data/orders.js that "cart" was reading "cårt" as part of our getCart function.

## Changes

- line 4 of "data/orders.js" read "return fetchWithResponse('cårt', {"; 
- line 4 now reads "return fetchWithResponse('cart', {"

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/cart` takes the customer to their cart

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "lineitems": [
        {
            "id": 4,
            "product": {
                "id": 52,
                "name": "Golf",
                "price": 653.59,
                "number_sold": 0,
                "description": "1994 Volkswagen",
                "quantity": 4,
                "created_date": "2019-07-10",
                "location": "Berlin",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        },
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "New York",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Optima",
                "price": 1655.15,
                "number_sold": 0,
                "description": "2008 Kia",
                "quantity": 3,
                "created_date": "2019-05-21",
                "location": "London",
                "image_path": "http://localhost:8000/media/products/vehicle.png",
                "average_rating": 0
            }
        }
    ],
    "products": [
        {
            "id": 52,
            "name": "Golf",
            "price": 653.59,
            "number_sold": 0,
            "description": "1994 Volkswagen",
            "quantity": 4,
            "created_date": "2019-07-10",
            "location": "Berlin",
            "image_path": "http://localhost:8000/media/products/vehicle.png",
            "average_rating": 0
        },
        {
            "id": 33,
            "name": "Optima",
            "price": 1655.15,
            "number_sold": 0,
            "description": "2008 Kia",
            "quantity": 3,
            "created_date": "2019-05-21",
            "location": "New York",
            "image_path": "http://localhost:8000/media/products/vehicle.png",
            "average_rating": 0
        },
        {
            "id": 71,
            "name": "Optima",
            "price": 1655.15,
            "number_sold": 0,
            "description": "2008 Kia",
            "quantity": 3,
            "created_date": "2019-05-21",
            "location": "London",
            "image_path": "http://localhost:8000/media/products/vehicle.png",
            "average_rating": 0
        }
    ],
    "size": 3
}
```

## Testing

- login and navigate to "Cart"--if a customer has items in their cart, you will see them reflected/no error code will be shown


## Related Issues

- Fixes #49