### PR TITLE
Bug/cart remove item

### DIFF
--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -7,13 +7,13 @@ export default function CartDetail({ cart, removeProduct }) {
   return (
     <Table headers={headers} footers={footers}>
       {
-        cart.products?.map(product => {
+        cart.lineitems?.map(item => {
           return (
-            <tr key={product.id}>
-              <td>{product.name}</td>
-              <td>{product.price}</td>
+            <tr key={item.id}>
+              <td>{item.product.name}</td>
+              <td>{item.product.price}</td>
               <td>
-                <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
+                <span className="icon is-clickable" onClick={() => removeProduct(item.id)}>
                   <i className="fas fa-trash"></i>
                 </span>
               </td>

--- a/data/products.js
+++ b/data/products.js
@@ -40,7 +40,7 @@ export function addProductToOrder(id) {
 }
 
 export function removeProductFromOrder(id) {
-  return fetchWithoutResponse(`products/${id}/remove-from-order`, {
+  return fetchWithoutResponse(`lineitems/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`

--- a/pages/register.js
+++ b/pages/register.js
@@ -37,7 +37,6 @@ export default function Register() {
       const res = await register(user); // Await the register call
       // console.log("Received registration request:", res);
       // console.log("Backend response:", res);
-debugger
       if (res && res.token) {
         setToken(res.token)
         router.push('/')


### PR DESCRIPTION
## Changes

- Updated url path argument passed to 'fetchWithoutResponse' function called in 'removeProductFromOrder' function in data/products.js to reflect API requirement
- Changed array being mapped over to 'lineitems' to gain access to primary key of orderproduct in database. This allows function to delete the orderproduct, not the product itself.
- updated jsx table elements values to reflect the above change. 

## Requests / Responses

**Request**

DELETE `/lineitems/${id}` removes the specified orderproduct from the database.


**Response**

HTTP/1.1 204 NO CONTENT


## Testing

- [ ] when logged in as an authenticated user, navigate to /cart and click trash icon next to an item. Confirm corresponding orderproduct is removed from database.

## Related Issues

- Fixes #37