### PR TITLE
Orders now being displayed on order page

### DIFF
--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -24,7 +24,7 @@ export default function Orders() {
           {
             orders.map((order) => (
               <tr key={order.id}>
-                <td>{order.completed_on}</td>
+                <td>{order.created_date}</td>
                 <td>${order.total}</td>
                 <td>{order.payment_type?.obscured_num}</td>
               </tr>


### PR DESCRIPTION
Orders were being displayed on order page without any data in their rows. This pull request includes the date completed, price, and hidden payment type. 

## Changes

- Changed order.completed_on to order.created_date when mapping through orders to display order date.

## Testing

- [ ] fetch matching API branch from github before testing this client
- [ ] log in as a user with closed orders (check db to confirm) and navigate to orders page. At a minimum, date should be be displayed. Order total should also be displayed.

## Related Issues

- Fixes #10