### PR TITLE
Corrected url and body for API call in data/orders.js

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,4 +1,4 @@
-import { fetchWithResponse } from './fetcher'
+import { fetchWithResponse, fetchWithoutResponse } from './fetcher'
 
 export function getCart() {
   return fetchWithResponse('cart', {
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithoutResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({"payment_type": paymentTypeId})
   })
 }


### PR DESCRIPTION
Request was being made to 'orders/${orderId}/complete'. completeCurrentOrder function was calling fetchWithResponse, even though the API was returning a 204 no content. Request body JSON was formatted in shorthand which was resulting in incorrectly named key.

## Changes

- Swapped fetchWithResponse for fetchWithoutResponse in completeCurrentOrder of data/orders.js
- Removed /complete from request URL 
- Changed JSON body to include a key of "payment_type"

## Requests / Responses

**Request**

PUT `/orders/${orderId}` adds payment type to referenced order

```json

{
    "payment_type": "3"
}

```

**Response**

HTTP/1.1 204 No Content

```json
{}
```

## Testing

Description of how to test code...

- [ ] Navigate to cart of current authenticated user, try joe
- [ ] Click complete order and add payment method, then click complete order in modal
- [ ] You should be taken to the orders page and the newly completed order should be listed 


## Related Issues

- Fixes #12
